### PR TITLE
RowHammer: Move inline asm rowhammer loop to assembly.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@ CFLAGS= -Wall -march=i486 -m32 -O0 -fomit-frame-pointer -fno-builtin \
 	
 OBJS= head.o reloc.o main.o test.o init.o lib.o patn.o screen_buffer.o \
       config.o cpuid.o linuxbios.o pci.o memsize.o spd.o error.o dmi.o controller.o \
-      smp.o vmem.o random.o
+      smp.o vmem.o random.o rowhammer.o
       
 
 all: clean memtest.bin memtest 
@@ -57,7 +57,10 @@ test.o: test.c
 
 random.o: random.c
 	$(CC) -c -Wall -march=i486 -m32 -O3 -fomit-frame-pointer -fno-builtin -ffreestanding random.c
-	
+
+rowhammer.o: rowhammer.S
+	$(AS) -32 -o rowhammer.o rowhammer.S
+
 # rule for build number generation  
 build_number:
 	sh make_buildnum.sh  

--- a/src/rowhammer.S
+++ b/src/rowhammer.S
@@ -1,0 +1,27 @@
+/* void do_rowhammer(char *addr1, char *addr2, int count); */
+/*
+ * Load from addr1, addr2; clflush addr1 and addr2; mfence; repeat count times.
+ * See 'Code 1' in ISCA '14 paper for code rationale.
+ *
+ * If addr1 and addr2 map to different rows of the same DRAM bank, it may
+ * be possible to witness other rows in the bank cleared, perhaps by
+ * coupling from repeated ACT/PRE signals on row activation lines.
+ */
+.globl do_rowhammer
+do_rowhammer:
+	movl	12(%esp), %ecx		/* count */
+	movl	8(%esp), %edx		/* addr2 */
+	movl	4(%esp), %eax		/* addr1 */
+	pushl	%esi
+	pushl	%edi
+	/* Core loop has no memory accesses beyond ifetch, load, clflush */
+1:	movl	(%eax), %esi		/* load addr1 */
+	movl	(%edx), %edi		/* load addr2 */
+	clflush	(%eax)			/* clflush addr1 */
+	clflush (%edx)			/* clflush addr2 */
+	mfence
+	decl	%ecx
+	jnz	1b
+	popl	%edi
+	popl	%esi
+	ret

--- a/src/test.c
+++ b/src/test.c
@@ -25,6 +25,7 @@ extern int test_ticks, nticks;
 extern struct tseq tseq[];
 extern void update_err_counts(void);
 extern void print_err_counts(void);
+extern void do_rowhammer(char *addr1, char *addr2, int count);
 void rand_seed( unsigned int seed1, unsigned int seed2, int me);
 ulong rand(int me);
 void poll_errors();
@@ -1580,13 +1581,7 @@ void rowhammer(int row_max, int *row_cnt, int toggle_max, int me)
                 break;
 
             // open and close row-pair (addr1 & addr2) repeatedly
-            for (int toggle = 0; toggle < toggle_max; toggle++) {
-                asm volatile("movl (%0), %%eax" : : "r" (addr1) : "eax");
-                asm volatile("movl (%0), %%ebx" : : "r" (addr2) : "ebx");
-                asm volatile("clflush (%0)" : : "r" (addr1) : "memory");
-                asm volatile("clflush (%0)" : : "r" (addr2) : "memory");
-                //asm volatile("mfence");
-            }
+            do_rowhammer(addr1, addr2, toggle_max);
 
             (*row_cnt)++;
 


### PR DESCRIPTION
The code fragment presented in the RowHammer paper has a core loop of
LOAD row1/LOAD row2/CLFLUSH row1/CLFLUSH row2/MFENCE.

In the memtest86+ test environment, with each statement as a separate
expression, there were other extraneous memory references in the core
loop that may be confounding the memory access pattern. Remove them by
using a raw .S file.
